### PR TITLE
Switched to getopt_long from my own (flawed) argument parser

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "date"]
 	path = submodules/date
 	url = https://github.com/HowardHinnant/date
+[submodule "submodules/fmt"]
+	path = submodules/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ else()
 endif()
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/submodules/date)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/submodules/fmt)
 
 file(GLOB_RECURSE FILES FOLLOW_SYMLINKS ${CMAKE_CURRENT_SOURCE_DIR} src/*.cpp)
 
@@ -43,6 +44,7 @@ target_link_libraries(
     ${PROJECT_NAME}
 
     date
+    fmt
 )
 
 ###

--- a/include/options.hpp
+++ b/include/options.hpp
@@ -1,0 +1,75 @@
+/**
+ * @file options.hpp
+ * @author Simon Cahill (simon@simonc.eu)
+ * @brief Contains the implementation of features required for use of getopt_long
+ * @version 0.1
+ * @date 2022-10-15
+ * 
+ * @copyright Copyright (c) 2022 Simon Cahill
+ */
+
+#ifndef ENDLESSH_REPORT_INCLUDE_OPTIONS_HPP
+#define ENDLESSH_REPORT_INCLUDE_OPTIONS_HPP
+
+#include "options.hpp"
+
+// stl
+#include <string>
+
+// libc
+#include <getopt.h>
+
+// fmt
+#include <fmt/format.h>
+
+using std::string;
+using std::string_view;
+
+constexpr string_view   getAppArgs() { return R"(icSandhvs:)"; }
+
+const option*           getAppOptions() {
+    const static option OPTIONS[] = {
+        { "no-ip-stats",    no_argument,        nullptr,    'i' },
+        { "no-cn-stats",    no_argument,        nullptr,    'c' },
+        { "stdin",          no_argument,        nullptr,    'S' },
+        { "abuse-ipdb",     no_argument,        nullptr,    'a' },
+        { "detailed",       no_argument,        nullptr,    'd' },
+        { "help",           no_argument,        nullptr,    'h' },
+        { "syslog",         required_argument,  nullptr,    's' },
+        { "version",        no_argument,        nullptr,    'v' },
+        { nullptr,          no_argument,        nullptr,     0  }
+    };
+
+    return OPTIONS;
+}
+
+inline string           getAppHelpText(const string_view& binName = getProjectName()) {
+    const static string HELP_TEXT_FMT = R"(
+{0:s} v{1:s} - {2:s}
+
+Usage:
+    {0:s}
+    {0:s} [options]
+    {0:s} --syslog/var/log/syslog.1
+    cat <file> | {0:s} --stdin
+
+Switches:
+    --no-ip-stats,  -i      Don't print IP statistics
+    --no-cn-stats,  -c      Don't print connection statistics
+    --stdin,        -s      Read logs from stdin
+    --abuse-ipdb,   -a      Enable AbuseIPDB-compatible CSV output
+    --no-ad,        -n      No advertising please!
+    --detailed,     -d      Provide detailed information
+    --help,         -h      Show this text and exit
+    --version,      -v      Display version information and exit
+
+Arguments:
+    --syslog [f],   -S[f]      Override syslog/endlessh log location
+)";
+
+    return fmt::format(HELP_TEXT_FMT, binName, getApplicationVersion(), getProjectDescription());
+}
+
+inline string           getAppVersionText() { return fmt::format(R"({0:s} v{1:s} - {2:s})", getProjectName(), getApplicationVersion(), getProjectDescription()); }
+
+#endif // ENDLESSH_REPORT_INCLUDE_OPTIONS_HPP

--- a/include/version.hpp.in
+++ b/include/version.hpp.in
@@ -17,4 +17,8 @@ using std::string_view;
 
 constexpr string_view getApplicationVersion() { return R"(@PROJECT_VERSION@)"; }
 
+constexpr string_view getProjectName() { return R"(@PROJECT_NAME@)"; }
+
+constexpr string_view getProjectDescription() { return R"(@PROJECT_DESCRIPTION@)"; }
+
 #endif // ENDLESSH_REPORT_INCLUDE_VERSION_HPP


### PR DESCRIPTION
The gist of this PR is that the list of arguments has grown since I first developed the application, so it just makes sense to use getopt_long instead of my own (very flawed) argument parser.

Possible flaws in my implementation:
 - Not adding a path when --syslog was passed as an argument
 - Something I've missed

Newly added libs:
 - libfmt

Also utilises Cmake and its build variables